### PR TITLE
python 3.6 fails, expecting builtin_types

### DIFF
--- a/supervisor/xmlrpc_lib.py
+++ b/supervisor/xmlrpc_lib.py
@@ -413,6 +413,8 @@ class SupervisorTransport(xmlrpc.client.Transport):
     connection = None
 
     _use_datetime = 0 # python 2.5 fwd compatibility
+    _use_builtin_types = False
+
     def __init__(self, username=None, password=None, serverurl=None):
         self.username = username
         self.password = password


### PR DESCRIPTION
error: <class 'AttributeError'>, 'SupervisorTransport' object has no attribute '_use_builtin_types': file: .../3.6/lib/python3.6/xmlrpc/client.py line: 1199